### PR TITLE
Renamed is_login function as it is now used by WordPress

### DIFF
--- a/functions/admin.php
+++ b/functions/admin.php
@@ -1,6 +1,6 @@
 <?php
 
-if (is_login()){
+if (is_login_page()){
 	add_action('login_head', 'login_scripts', 0);
 }
 

--- a/functions/base.php
+++ b/functions/base.php
@@ -67,7 +67,7 @@ class Config{
 		);
 		$attr = array_merge($default, $attr);
 
-		$is_admin = (is_admin() or is_login());
+		$is_admin = (is_admin() or is_login_page());
 
 		if (
 			($attr['admin'] and $is_admin) or
@@ -108,7 +108,7 @@ class Config{
 		);
 		$attr = array_merge($default, $attr);
 
-		$is_admin = (is_admin() or is_login());
+		$is_admin = (is_admin() or is_login_page());
 
 		if (
 			($attr['admin'] and $is_admin) or
@@ -808,7 +808,7 @@ function get_menu($name, $classes=null, $id=null, $callback=null){
  * @return boolean
  * @author Jared Lang
  **/
-function is_login(){
+function is_login_page(){
 	return in_array($GLOBALS['pagenow'], array(
 			'wp-login.php',
 			'wp-register.php',


### PR DESCRIPTION
WordPress has added a function called `is_login` in one of its recent updates, so we need to rename our `is_login` function within the old UCF Theme is not conflict.