### PR TITLE
Added logic that allows us to unset the CTA

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -109,9 +109,11 @@ function get_parallax_page_header($page_id) {
 				<div class="row parallax-header-inner">
 					<div class="span12 parallax-header-inner">
 						<h1><?=$page->post_title?></h1>
+						<?php if ( $cta = get_cta_link() ) : ?>
 						<div class="cta">
-							<?php print get_cta_link(); ?>
+							<?php print $cta; ?>
 						</div>
+						<?php endif; ?>
 					</div>
 				</div>
 			</div>

--- a/functions/config.php
+++ b/functions/config.php
@@ -106,7 +106,9 @@ Config::$body_classes = array('default',);
  * Grab array of pages for Config::$theme_settings:
  **/
 $pages = get_posts(array('post_type' => 'page'));
-$pages_array = array();
+$pages_array = array(
+	"None" => null
+);
 foreach ($pages as $page) {
 	$pages_array[$page->post_title] = $page->ID;
 }


### PR DESCRIPTION
Allow us to "unset" the CTA page, preventing the gold button from appearing in the page header.